### PR TITLE
fix javadoc errors

### DIFF
--- a/Dynamo/src/main/java/couk/doridori/dynamo/DynamoHolder.java
+++ b/Dynamo/src/main/java/couk/doridori/dynamo/DynamoHolder.java
@@ -49,7 +49,8 @@ public class DynamoHolder<T>
 
     /**
      * @param meta See the doc for this class {@link couk.doridori.dynamo.DynamoHolder}
-     * @return
+     * @param dynamoFactory Factory that defines how to build a Dynamo
+     * @return an existing Dynamo associated with meta, or a new one if no association exists
      */
     public T getDynamo(String meta, DynamoFactory<T> dynamoFactory)
     {

--- a/Dynamo/src/main/java/couk/doridori/dynamo/StateMachine.java
+++ b/Dynamo/src/main/java/couk/doridori/dynamo/StateMachine.java
@@ -19,7 +19,7 @@ package couk.doridori.dynamo;
  * Simple state machine. If need something that needs to handle a big transition matrix look at the SMC compiler
  *
  * Takes a generic so you can define you own root states. Can just use {@link StateMachine.State} if
- * your you are not going to use a base State interface for View->Dynamo comms.
+ * your you are not going to use a base State interface for View-{@literal >}Dynamo comms.
  *
  * User: doriancussen
  * Date: 05/11/2012


### PR DESCRIPTION
currently the ./gradlew build fails because of missing javadoc items. I've tried to fill them out based on what I understand so far of Dynamo.
