### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
-#1.0.1
+# 1.0.1
 
 - Bug fix for issue [#8](https://github.com/doridori/Dynamo/issues/8) where a synchronous state change would result is the current State change being observed multiple times
 
-#1.0.0
+# 1.0.0
 
 - Initial release

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 [![Android Arsenal](https://img.shields.io/badge/Android%20Arsenal-Dynamo-brightgreen.svg?style=flat)](http://android-arsenal.com/details/1/1805) [![Circle CI](https://circleci.com/gh/doridori/Dynamo.svg?style=shield&circle-token=:circle-token)](https://circleci.com/gh/doridori/Dynamo) [![](https://img.shields.io/badge/AndroidWeekly-%23150-blue.svg)](http://androidweekly.net/issues/issue-150)
 
-#DEPRECATED
+# DEPRECATED
 
 This project is now deprecated and superseded by:
 


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
